### PR TITLE
Mark project as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+## Deprecated
+This project is not being developed. Feel free to fork!
+
 # pool-shard
 
 Pools of sharded PostgreSQL database connections.


### PR DESCRIPTION
The description should probably be prefixed with "Deprecated" as well.